### PR TITLE
docs: editサブコマンドの使い方をREADMEに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ gh cgu use <key>
 gh cgu add <name> <email>
 gh cgu add <name> <email> --key <key>  # specify key explicitly (e.g. for non-ASCII names)
 
+# Edit an existing profile
+gh cgu edit <key> --name <name>
+gh cgu edit <key> --email <email>
+gh cgu edit <key> --key <new-key>
+
 # Remove a profile
 gh cgu remove <key>
 


### PR DESCRIPTION
PR #4 で追加した `edit` サブコマンドの使い方が README に記載されていなかったため追記。