### PR TITLE
feat: addコマンドで既存キーへの上書きを禁止

### DIFF
--- a/cmd_add.go
+++ b/cmd_add.go
@@ -47,6 +47,10 @@ func toKey(s string) string {
 
 // addProfile adds a new profile with the given display name, email, and key
 func addProfile(v *viper.Viper, name, email, key string) {
+	if v.IsSet(key) {
+		cobra.CheckErr(fmt.Errorf("profile %q already exists, use 'gh cgu edit %s' to update it", key, key))
+	}
+
 	configMap := v.AllSettings()
 	if configMap == nil {
 		configMap = make(map[string]interface{})


### PR DESCRIPTION
同じキーで `gh cgu add` を実行した場合にエラーを返すようにした。

```
Error: profile "alice" already exists, use 'gh cgu edit alice' to update it
```