### PR TITLE
fix: プロフィール存在チェックをv.IsSet(key)に統一

### DIFF
--- a/cmd_edit.go
+++ b/cmd_edit.go
@@ -29,11 +29,14 @@ var editCmd = &cobra.Command{
 
 // editProfile updates an existing profile's name, email, and/or key
 func editProfile(v *viper.Viper, key, name, email, newKey string, changeName, changeEmail, changeKey bool) {
+	if !v.IsSet(key) {
+		cobra.CheckErr(fmt.Errorf("profile %q not found, run 'gh cgu list' to see available profiles", key))
+	}
+
 	currentName := v.GetString(key + ".name")
 	currentEmail := v.GetString(key + ".email")
-
 	if currentName == "" || currentEmail == "" {
-		cobra.CheckErr(fmt.Errorf("profile %q not found, run 'gh cgu list' to see available profiles", key))
+		cobra.CheckErr(fmt.Errorf("profile %q is corrupted: missing name or email", key))
 	}
 
 	if !changeName {

--- a/cmd_remove.go
+++ b/cmd_remove.go
@@ -25,9 +25,7 @@ var removeCmd = &cobra.Command{
 
 // removeProfile removes a profile by key
 func removeProfile(v *viper.Viper, key string) {
-	email := v.GetString(key + ".email")
-
-	if email == "" {
+	if !v.IsSet(key) {
 		cobra.CheckErr(fmt.Errorf("profile %q not found, run 'gh cgu list' to see available profiles", key))
 	}
 

--- a/cmd_use.go
+++ b/cmd_use.go
@@ -37,11 +37,14 @@ func switchToProfile(v *viper.Viper, key string) {
 		cobra.CheckErr(err)
 	}
 
+	if !v.IsSet(key) {
+		cobra.CheckErr(fmt.Errorf("profile %q not found, run 'gh cgu list' to see available profiles", key))
+	}
+
 	name := v.GetString(key + ".name")
 	email := v.GetString(key + ".email")
-
 	if name == "" || email == "" {
-		cobra.CheckErr(fmt.Errorf("profile %q not found, run 'gh cgu list' to see available profiles", key))
+		cobra.CheckErr(fmt.Errorf("profile %q is corrupted: missing name or email", key))
 	}
 
 	err := exec.Command("git", "config", "user.name", name).Run()


### PR DESCRIPTION
edit / remove / use コマンドで、プロフィールの存在確認を `v.IsSet(key)` で統一した。

あわせて edit / use では `IsSet` 通過後も name または email が空の場合に corrupted エラーを出すようにした。

### Before
- `editProfile`: `currentName == "" || currentEmail == ""` で判定
- `removeProfile`: `email == ""` のみで判定（非対称）
- `switchToProfile`: `name == "" || email == ""` で判定

### After
すべて `v.IsSet(key)` で not found を判定。edit / use は追加で corrupted チェックを実施。